### PR TITLE
Feature/snmp get by block

### DIFF
--- a/gapit-snmp.js
+++ b/gapit-snmp.js
@@ -662,7 +662,7 @@ module.exports = function (RED) {
             let blockSize = 0;
             if (node.getBlockSize !== undefined) {
                 blockSize = node.getBlockSize;
-                console.debug(`Getting OIDs in blocks of ${blockSize}`);
+                console.debug(`Querying OIDs in blocks of ${blockSize}, total number of OIDs is ${oids.length}`);
                 // For testing, remove always-failing (in simulator) oid from list.
                 // let simFailingOidIndex = oids.indexOf("1.3.6.1.4.1.534.1.9.7.0.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2.1.2")
                 // if (simFailingOidIndex != -1) {
@@ -671,7 +671,7 @@ module.exports = function (RED) {
             }
             else {
                 blockSize = oids.length;
-                console.debug("Getting all OIDs in a single request");
+                console.debug("Querying all OIDs in a single request");
             }
 
             msg.varbinds = Array();

--- a/gapit-snmp.js
+++ b/gapit-snmp.js
@@ -630,7 +630,7 @@ module.exports = function (RED) {
                     // error object has .name, .message and, optionally, .status
                     // error.status is only set for RequestFailed, so check
                     // that it's this error before checking the value of .status
-                    if((error.name == "RequestFailedError") && (error.status == snmp.ErrorStatus.NoSuchName)) {
+                    if ((error.name == "RequestFailedError") && (error.status == snmp.ErrorStatus.NoSuchName)) {
                         // SNMPv1 NoSuchName
                         // A single "missing" OID causes an SNMPv1 query to fail, 
                         // query OIDs one by one as a workaround

--- a/gapit-snmp.js
+++ b/gapit-snmp.js
@@ -637,6 +637,16 @@ module.exports = function (RED) {
                         node.warn(`Still tooBig, trying again with ${blockSize} OIDs`);
                         node.tuneSnmpBlockSize(host, community, oids, msg, blockSize);
                     }
+                    else if ((error.name == "RequestFailedError") && (error.status == snmp.ErrorStatus.NoSuchName)) {
+                        // As soon as tooBig is no longer triggered, this error
+                        // may occur.
+                        //
+                        // SNMPv1 NoSuchName
+                        // A single "missing" OID causes an SNMPv1 query to fail, 
+                        // query OIDs one by one as a workaround
+                        node.warn("SNMPv1 NoSuchName, will query all OIDs individually");
+                        node.snmpGetIndividualOids(host, community, oids, msg);
+                    }
                     else {
                         node.error("Request error: " + error.toString(), msg);
                     }


### PR DESCRIPTION
If the response to an SNMP query becomes too large, e.g. by querying too many OIDs at the same time, it will generate an SNMP tooBig error. There's a limit in the protocol, but hitting a limit in a particular device implementation is more likely. This PR handles this error by finding the limit to how many OIDs can be queried at once, and then dividing future queries into blocks of OIDs.

The block size tuning starts at the number of OIDs - 10 (rounded down to the closest 10), and continues trying 10 less until a successful query is made.

Fixes #3.
